### PR TITLE
Fjerner unleash-proxy-referanse

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
       APP_BASE_URL: 'http://localhost:8100'
       APP_BASE_PATH: '/dekoratoren'
       API_XP_SERVICES_URL: 'https://www.nav.no/_/service'
-      API_UNLEASH_PROXY_URL: 'https://www.nav.no/person/pb-unleash-proxy'
       API_INNLOGGINGSLINJE_URL: "http://localhost:8095/innloggingsstatus"
       API_VARSELINNBOKS_URL: 'http://mocks:8080/person/varselinnboks'
       MINSIDE_ARBEIDSGIVER_URL: 'http://localhost:8080/min-side-arbeidsgiver/'


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fjerner ubrukt referanse i til gammel Unleash-proxy
